### PR TITLE
fix removal of nuvlabox credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+  - Fix misspelled method name in NuvlaBox decommissioning job that
+    blocked deletion of NuvlaBox resources. 
+
 ## [2.3.4] - 2019-08-07
 
 ### Changed

--- a/code/src/nuvla/job/actions/nuvlabox_decommission.py
+++ b/code/src/nuvla/job/actions/nuvlabox_decommission.py
@@ -31,7 +31,7 @@ class NuvlaBoxDeleteJob(object):
             logging.warning('problem querying collection {}.'.format(collection))
 
     def delete_api_key(self, nuvlabox_id):
-        self.deleted_linked_resources('credential', nuvlabox_id)
+        self.delete_linked_resources('credential', nuvlabox_id)
 
     # FIXME: This will currently leave orphan data-object and data-record resources!
     def delete_s3_credential(self, credential_id):


### PR DESCRIPTION
Fix typo in nuvlabox decommission script that prevents nuvlabox credentials (and the nuvlabox itself) from being deleted.