### PR TITLE
fix running replicas; add current task info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 *.egg-info/
 *.iml
 .idea
-venv
+venv*
 target
 versions.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+  - Fix calculation of replicas.running to properly take into account
+    the running task state
+  - Add deployment parameters to provide information about current
+    Docker task: current.desired.state, current.state, and current.error. 
   - Fix misspelled method name in NuvlaBox decommissioning job that
     blocked deletion of NuvlaBox resources. 
 

--- a/code/src/nuvla/job/actions/deployment.py
+++ b/code/src/nuvla/job/actions/deployment.py
@@ -114,6 +114,12 @@ class Deployment(object):
         param = self._get_parameter(resource_id, node_id, name, select='id')
         return self.nuvla.edit(param.id, {'value': value})
 
+    def set_parameter_ignoring_errors(self, resource_id, node_id, name, value):
+        try:
+            self.set_parameter(resource_id, node_id, name, value)
+        except Exception as _:
+            pass
+
     def set_parameter_create_if_needed(self, resource_id, user_id, param_name, param_value=None,
                                        node_id=None, param_description=None):
         try:
@@ -160,6 +166,16 @@ class Deployment(object):
 
 
 class DeploymentParameter(object):
+
+    CURRENT_DESIRED = {'name': 'current.desired.state',
+                       'description': "Desired state of the container's current task."}
+
+    CURRENT_STATE = {'name': 'current.state',
+                     'description': "Desired state of the container's current task."}
+
+    CURRENT_ERROR = {'name': 'current.error.message',
+                     'description': "Desired state of the container's current task."}
+
     REPLICAS_DESIRED = {'name': 'replicas.desired',
                         'description': 'Desired number of service replicas.'}
 

--- a/code/src/nuvla/job/actions/deployment.py
+++ b/code/src/nuvla/job/actions/deployment.py
@@ -171,10 +171,10 @@ class DeploymentParameter(object):
                        'description': "Desired state of the container's current task."}
 
     CURRENT_STATE = {'name': 'current.state',
-                     'description': "Desired state of the container's current task."}
+                     'description': "Actual state of the container's current task."}
 
     CURRENT_ERROR = {'name': 'current.error.message',
-                     'description': "Desired state of the container's current task."}
+                     'description': "Error message (if any) of the container's current task."}
 
     REPLICAS_DESIRED = {'name': 'replicas.desired',
                         'description': 'Desired number of service replicas.'}

--- a/code/src/nuvla/job/actions/deployment_start.py
+++ b/code/src/nuvla/job/actions/deployment_start.py
@@ -110,6 +110,30 @@ class DeploymentStartJob(object):
             param_description=DeploymentParameter.HOSTNAME['description'],
             node_id=node_instance_name)
 
+        self.create_deployment_parameter(
+            deployment_id=deployment_id,
+            user_id=deployment_owner,
+            param_name=DeploymentParameter.CURRENT_DESIRED['name'],
+            param_value="",
+            param_description=DeploymentParameter.CURRENT_DESIRED['description'],
+            node_id=node_instance_name)
+
+        self.create_deployment_parameter(
+            deployment_id=deployment_id,
+            user_id=deployment_owner,
+            param_name=DeploymentParameter.CURRENT_STATE['name'],
+            param_value="",
+            param_description=DeploymentParameter.CURRENT_STATE['description'],
+            node_id=node_instance_name)
+
+        self.create_deployment_parameter(
+            deployment_id=deployment_id,
+            user_id=deployment_owner,
+            param_name=DeploymentParameter.CURRENT_ERROR['name'],
+            param_value="",
+            param_description=DeploymentParameter.CURRENT_ERROR['description'],
+            node_id=node_instance_name)
+
         # FIXME: get number of desired replicas of Replicated service from deployment. 1 for now.
         desired = 1
         self.create_deployment_parameter(

--- a/code/src/nuvla/job/actions/deployment_state.py
+++ b/code/src/nuvla/job/actions/deployment_state.py
@@ -49,19 +49,16 @@ class DeploymentStateJob(object):
                 current_error = current_status.get('Err', "no error")
 
             if current_desired is not None:
-                self.api_dpl.set_parameter_ignoring_errors(did, sname,
-                                                           DeploymentParameter.CURRENT_DESIRED['name'],
-                                                           current_desired)
+                self.api_dpl.set_parameter_ignoring_errors(
+                    did, sname, DeploymentParameter.CURRENT_DESIRED['name'], current_desired)
 
             if current_state is not None:
-                self.api_dpl.set_parameter_ignoring_errors(did, sname,
-                                                           DeploymentParameter.CURRENT_STATE['name'],
-                                                           current_state)
+                self.api_dpl.set_parameter_ignoring_errors(
+                    did, sname, DeploymentParameter.CURRENT_STATE['name'], current_state)
 
             if current_error is not None:
-                self.api_dpl.set_parameter_ignoring_errors(did, sname,
-                                                           DeploymentParameter.CURRENT_ERROR['name'],
-                                                           current_error)
+                self.api_dpl.set_parameter_ignoring_errors(
+                    did, sname, DeploymentParameter.CURRENT_ERROR['name'], current_error)
 
         t_running = list(filter(lambda x:
                                 x['DesiredState'] == 'running' and


### PR DESCRIPTION
Fix the calculation of the running replicas to properly take into account the state of the task.

Add current.desired.state, current.state, and current.error to provide more information about the current Docker task. This will also display problems occurring at the Docker level to the user.