### PR TITLE
Fix and improve K8s install on Azure and Google

### DIFF
--- a/code/src/nuvla/connector/docker_machine_connector.py
+++ b/code/src/nuvla/connector/docker_machine_connector.py
@@ -627,6 +627,10 @@ class DockerMachineConnector(Connector):
             log.warning('No nodes provided to stop.')
             return
         log.info(f'Stopping {n} nodes on {self.driver_name}.')
+
+        if self.driver_name == 'google':
+            self.cmd_env['GOOGLE_APPLICATION_CREDENTIALS'] = self._build_gce_adc()
+
         pool = multiprocessing.Pool(min(DEFAULT_POOL_SIZE, n))
         try:
             stopped = pool.starmap(self._stop_node,

--- a/code/src/nuvla/connector/docker_machine_connector.py
+++ b/code/src/nuvla/connector/docker_machine_connector.py
@@ -95,6 +95,7 @@ class DockerMachineConnector(Connector):
                            'azure-location'],
                   'defaults': {'azure-image': 'canonical:UbuntuServer:16.04.0-LTS:latest',
                                'azure-open-port': '2377',
+                               'azure-ssh-user': 'ubuntu',
                                'azure-location': 'francecentral'}
                   },
         "google": {'args': ['google-project',
@@ -332,8 +333,11 @@ class DockerMachineConnector(Connector):
                     f'{machine_name}:{k8s_script_remote}', env=env)
 
         log.info(f'Install K8s on {machine_name}')
+        # IP for extra Subject Alternative Name for API server cert when host IP
+        # is different from public.
+        ip = machine.ip(machine_name, env=env)
         machine.ssh(machine_name,
-            f'chmod +x {k8s_script_remote}; {k8s_script_remote} {machine_kind}',
+            f'chmod +x {k8s_script_remote}; {k8s_script_remote} {machine_kind} {ip}',
             env=env)
         log.info(f'Installed K8s on {machine_name}')
 
@@ -570,6 +574,7 @@ class DockerMachineConnector(Connector):
             msg = f'{self.coe_type.title()} cluster of size {len(inventory.all())} on {self.driver_name}'
             log.info(f'Provisioning COE {msg}.')
             self._provision_cluster(nodes, inventory)
+            self._push_ssh_keys(inventory, self.ssh_keys)
             join_tokens = self._create_coe(inventory, nodes)
             log.info(f'Provisioned COE {msg}.')
 
@@ -577,8 +582,6 @@ class DockerMachineConnector(Connector):
                       'endpoint': self._coe_endpoint(inventory),
                       'join-tokens': join_tokens,
                       'nodes': nodes}
-
-            self._push_ssh_keys(inventory, self.ssh_keys)
 
             if self.coe_manager_install:
                 result['coe-manager-endpoint'] = self._install_coe_manager(inventory)

--- a/code/src/nuvla/connector/docker_machine_connector.py
+++ b/code/src/nuvla/connector/docker_machine_connector.py
@@ -104,6 +104,7 @@ class DockerMachineConnector(Connector):
                             'google-machine-type'],
                    'defaults': {'google-machine-image': 'ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200610',
                                 'google-open-port': '2377',
+                                'google-machine-type': 'e2-medium',
                                 'google-zone': 'europe-west3-a'}
                    }
     }

--- a/code/src/nuvla/connector/extra/k8s-install.sh
+++ b/code/src/nuvla/connector/extra/k8s-install.sh
@@ -2,8 +2,10 @@
 set -ex
 
 ROLE=${1:?"Role: manager or worker"}
+# Extra Subject Alternative Names for the API server.
+EXTRA_SANS=${2}
 
-K8S_VER=1.18.0-00
+K8S_VER=1.18.5-00
 
 # "Fix" docker daemon: https://github.com/kubernetes/kubeadm/issues/1394#issuecomment-462878219
 cat > /tmp/daemon.json <<EOF
@@ -20,7 +22,10 @@ sudo mkdir -p /etc/systemd/system/docker.service.d
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 
+sudo sh -c "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 sudo apt-get update
+sudo apt-get install dialog apt-utils -y -q
+
 sudo sudo apt-get install -y apt-transport-https
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
@@ -32,10 +37,15 @@ sudo apt-get update
 sudo apt-get install -y kubelet=$K8S_VER kubeadm=$K8S_VER
 if [ "$ROLE" == "manager" ]; then
     sudo apt-get install -y --allow-downgrades kubectl=$K8S_VER
-    sudo kubeadm init --pod-network-cidr=10.244.0.0/16
-    mkdir $HOME/.kube
-    sudo cp /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
-    sudo chown ubuntu. .kube/config
+    if [ ! -z "${EXTRA_SANS}" ]; then
+      sudo kubeadm init --pod-network-cidr=10.244.0.0/16 --apiserver-cert-extra-sans "$EXTRA_SANS"
+    else
+      sudo kubeadm init --pod-network-cidr=10.244.0.0/16
+    fi
+    mkdir -p $HOME/.kube
+    sudo cp /etc/kubernetes/admin.conf $HOME/.kube/config
+    export user_name=$(id -u -n)
+    sudo chown $user_name:$user_name $HOME/.kube/config
     kubectl cluster-info
     KF=https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
     kubectl apply -f $KF 2>&1 | tee pod_network_setup.txt


### PR DESCRIPTION
This PR fixes and improves K8s installation on Azure and Google.

- install K8s 0.18.5
- add SANs to K8s API server cert
- improve handling on user when getting kubconfig from VM
- use ubuntu user on Azure
- use VM with 2CPU on Google
- push ssh keys right after VMs provisioned.