### PR TITLE
don't run jobs whose version is higher than engines

### DIFF
--- a/code/src/nuvla/job/job.py
+++ b/code/src/nuvla/job/job.py
@@ -48,8 +48,9 @@ class Job(dict):
                 self.id = self.id.decode()
                 cimi_job = self.get_cimi_job(self.id)
                 dict.__init__(self, cimi_job)
-                if version_to_tuple(self.get('version')) > self._engine_version:
-                    log.warning(f"Job's version {self.get('version')} is higher than engine's {self._engine_version}. "
+                job_version = str(self.get('version', 0))
+                if version_to_tuple(job_version) > self._engine_version:
+                    log.warning(f"Job's version {job_version} is higher than engine's {self._engine_version}. "
                                 "Putting job back to the queue.")
                     retry_kazoo_queue_op(self.queue, "release")
                     self.nothing_to_do = True

--- a/code/src/nuvla/job/job.py
+++ b/code/src/nuvla/job/job.py
@@ -49,7 +49,7 @@ class Job(dict):
                 cimi_job = self.get_cimi_job(self.id)
                 dict.__init__(self, cimi_job)
                 if version_to_tuple(self.get('version')) > self._engine_version:
-                    log.warning(f"Job's version {self.version} is higher than engine's {self._engine_version}. "
+                    log.warning(f"Job's version {self.get('version')} is higher than engine's {self._engine_version}. "
                                 "Putting job back to the queue.")
                     retry_kazoo_queue_op(self.queue, "release")
                     self.nothing_to_do = True

--- a/code/src/nuvla/job/job.py
+++ b/code/src/nuvla/job/job.py
@@ -2,6 +2,7 @@
 
 import time
 import logging
+import re
 
 from nuvla.api import NuvlaError, ConnectionError
 
@@ -11,9 +12,14 @@ from .version import version as engine_version
 
 log = logging.getLogger('job')
 
+VER_TRIM_RE = re.compile('-.*$')
+
 
 def version_to_tuple(ver: str) -> tuple:
-    return tuple(map(int, ver.strip('-SNAPSHOT').split('.')))
+    ver_ = list(map(int, VER_TRIM_RE.sub('', ver).split('.')))
+    if len(ver_) < 2:
+        return ver_[0], 0, 0
+    return tuple(ver_)
 
 
 class NonexistentJobError(Exception):
@@ -37,6 +43,10 @@ class Job(dict):
         self.queue = queue
         self.api = api
         self._engine_version = version_to_tuple(engine_version)
+        if self._engine_version[0] < 2:
+            self._engine_version_min = (0, 0, 1)
+        else:
+            self._engine_version_min = (self._engine_version[0] - 1, 0, 0)
         self._init()
 
     def _init(self):
@@ -48,12 +58,7 @@ class Job(dict):
                 self.id = self.id.decode()
                 cimi_job = self.get_cimi_job(self.id)
                 dict.__init__(self, cimi_job)
-                job_version = str(self.get('version', 0))
-                if version_to_tuple(job_version) > self._engine_version:
-                    log.warning(f"Job's version {job_version} is higher than engine's {engine_version}. "
-                                "Putting job back to the queue.")
-                    retry_kazoo_queue_op(self.queue, "release")
-                    self.nothing_to_do = True
+                self._job_version_check()
                 if self.is_in_final_state():
                     retry_kazoo_queue_op(self.queue, "consume")
                     log.warning('Newly retrieved {} already in final state! Removed from queue.'
@@ -76,6 +81,31 @@ class Job(dict):
                 'Will go back to work after {}s.'.format(timeout))
             log.exception(e)
             time.sleep(timeout)
+            self.nothing_to_do = True
+
+    def _job_version_check(self):
+        """Skips the job by setting `self.nothing_to_do = True` when the job's
+        version is outside of the engine's supported closed range [M-1, M.m.P].
+        Where M is major version from semantic version definition M.m.P.
+        The job will be removed from the queue and set as failed if the job's
+        version is strictly lower than M-1.
+        The job will be skipped if its version is strictly greater engine's M.m.P.
+        (This can happen for a short while during upgrades when jobs distribution
+        gets upgraded before the job engine.)
+        """
+        job_version_str = str(self.get('version', '0.0.1'))
+        job_version = version_to_tuple(job_version_str)
+        if job_version < self._engine_version_min:
+            evm_str = '.'.join(map(str, self._engine_version_min))
+            msg = f"Job version {job_version_str} is smaller than min supported {evm_str}"
+            log.warning(msg)
+            retry_kazoo_queue_op(self.queue, "consume")
+            self.update_job(state='FAILED', status_message=msg)
+            self.nothing_to_do = True
+        elif job_version > self._engine_version:
+            log.debug(f"Job version {job_version_str} is higher than engine's {engine_version}. "
+                      "Putting job back to the queue.")
+            retry_kazoo_queue_op(self.queue, "release")
             self.nothing_to_do = True
 
     def get_cimi_job(self, job_uri):

--- a/code/src/nuvla/job/version.py
+++ b/code/src/nuvla/job/version.py
@@ -1,0 +1,1 @@
+version = '${project.version}'

--- a/code/tests/job_test.py
+++ b/code/tests/job_test.py
@@ -1,0 +1,26 @@
+import unittest
+from mock import Mock
+
+from nuvla.job import job
+
+
+class TestJob(unittest.TestCase):
+
+    def test_job_version(self):
+        queue = Mock()
+        queue.get = Mock(return_value=b'foo')
+
+        job.engine_version = '0.0.1'
+        job.Job.get_cimi_job = Mock(return_value={'version': '0.0.1'})
+        jb = job.Job(None, queue)
+        assert jb.nothing_to_do == False
+
+        job.engine_version = '0.0.1'
+        job.Job.get_cimi_job = Mock(return_value={'version': '0.0.2'})
+        jb = job.Job(None, queue)
+        assert jb.nothing_to_do
+
+        job.engine_version = '0.0.1-SNAPSHOT'
+        job.Job.get_cimi_job = Mock(return_value={'version': '0.0.2'})
+        jb = job.Job(None, queue)
+        assert jb.nothing_to_do

--- a/code/tests/job_test.py
+++ b/code/tests/job_test.py
@@ -10,23 +10,87 @@ class TestJob(unittest.TestCase):
         queue = Mock()
         queue.get = Mock(return_value=b'foo')
 
-        job.engine_version = '0.0.1'
-        job.Job.get_cimi_job = Mock(return_value={'version': '0.0.1'})
-        jb = job.Job(None, queue)
-        assert jb.nothing_to_do == False
+        # No job version provided with the job. It will be set to the min value.
+        # The job will be processed until engine's version is below 2.0.0.
+        for ev in ['0.0.1', '1.0.0', '1.2.3']:
+            job.engine_version = ev
+            job.Job.get_cimi_job = Mock(return_value={})
+            job.Job.update_job = Mock()
+            jb = job.Job(None, queue)
+            assert jb.nothing_to_do is False
 
+        # No job version provided with the job. It will be set to the min value.
+        # The job will not be processed and removed from the queue.
+        job.engine_version = '2.0.0'
+        job.Job.get_cimi_job = Mock(return_value={})
+        job.Job.update_job = Mock()
+        job.retry_kazoo_queue_op = Mock()
+        jb = job.Job(None, queue)
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "consume")
+        jb.update_job.assert_called_once()
+        assert jb.nothing_to_do is True
+
+        # Job version is strictly smaller than M-1 of job engine version.
+        # The job will not be processed and removed from the queue.
+        job.engine_version = '3.2.1'
+        job.Job.get_cimi_job = Mock(return_value={'version': '1.2.3'})
+        job.Job.update_job = Mock()
+        job.retry_kazoo_queue_op = Mock()
+        jb = job.Job(None, queue)
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "consume")
+        jb.update_job.assert_called_once()
+        assert jb.nothing_to_do is True
+
+        # The job version might only indicate the major number.
+        # Job version is strictly smaller than M-1 of job engine version.
+        job.engine_version = '3.2.1'
+        job.Job.get_cimi_job = Mock(return_value={'version': '1'})
+        job.Job.update_job = Mock()
+        job.retry_kazoo_queue_op = Mock()
+        jb = job.Job(None, queue)
+        jb.update_job.assert_called_once()
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "consume")
+        assert jb.nothing_to_do is True
+
+        # The job version might only indicate the major number.
+        # Versions are equal. Job will be processed.
+        job.engine_version = '1.0.0'
+        job.Job.get_cimi_job = Mock(return_value={'version': '1'})
+        job.Job.update_job = Mock()
+        jb = job.Job(None, queue)
+        assert jb.nothing_to_do is False
+
+        # Job and engine versions are equal.
+        # Job will be processed.
+        for v in ['0.0.1', '1.0.0', '7.6.5']:
+            job.engine_version = v
+            job.Job.get_cimi_job = Mock(return_value={'version': v})
+            job.Job.update_job = Mock()
+            job.retry_kazoo_queue_op = Mock()
+            jb = job.Job(None, queue)
+            jb.update_job.assert_not_called()
+            job.retry_kazoo_queue_op.assert_not_called()
+            assert jb.nothing_to_do is False
+
+        # Job's version is higher that engine's.
+        # Job is put back to the queue.
         job.engine_version = '0.0.1'
         job.Job.get_cimi_job = Mock(return_value={'version': '0.0.2'})
+        job.retry_kazoo_queue_op = Mock()
         jb = job.Job(None, queue)
-        assert jb.nothing_to_do
-
-        # the job version might only indicate the major number
-        job.engine_version = '0.0.1'
-        job.Job.get_cimi_job = Mock(return_value={'version': '0'})
-        jb = job.Job(None, queue)
-        assert jb.nothing_to_do == False
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "release")
+        assert jb.nothing_to_do is True
 
         job.engine_version = '0.0.1-SNAPSHOT'
         job.Job.get_cimi_job = Mock(return_value={'version': '0.0.2'})
+        job.retry_kazoo_queue_op = Mock()
         jb = job.Job(None, queue)
-        assert jb.nothing_to_do
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "release")
+        assert jb.nothing_to_do is True
+
+        job.engine_version = '7.6.5'
+        job.Job.get_cimi_job = Mock(return_value={'version': '8.0.1'})
+        job.retry_kazoo_queue_op = Mock()
+        jb = job.Job(None, queue)
+        job.retry_kazoo_queue_op.assert_called_once_with(queue, "release")
+        assert jb.nothing_to_do is True

--- a/code/tests/job_test.py
+++ b/code/tests/job_test.py
@@ -20,6 +20,12 @@ class TestJob(unittest.TestCase):
         jb = job.Job(None, queue)
         assert jb.nothing_to_do
 
+        # the job version might only indicate the major number
+        job.engine_version = '0.0.1'
+        job.Job.get_cimi_job = Mock(return_value={'version': '0'})
+        jb = job.Job(None, queue)
+        assert jb.nothing_to_do == False
+
         job.engine_version = '0.0.1-SNAPSHOT'
         job.Job.get_cimi_job = Mock(return_value={'version': '0.0.2'})
         jb = job.Job(None, queue)

--- a/container-lite/pom.xml
+++ b/container-lite/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>sixsq.nuvla.job-engine</groupId>
     <artifactId>job-engine</artifactId>
-    <version>2.9.1-SNAPSHOT</version>
+    <version>2.10.1-SNAPSHOT</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
Is that strict comparison enough or we want to allow PATCH version of the job to be higher than the engine's?

Related to #134