### PR TITLE
docker-compose validation - support port env var substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+ - docker-compose validation - support port env var substitution
+
 ## [2.13.0] - 2021-02-22
 
 ### Changed

--- a/code/src/nuvla/job/actions/application_docker_compose_validate.py
+++ b/code/src/nuvla/job/actions/application_docker_compose_validate.py
@@ -19,7 +19,7 @@ class ApplicationDockerComposeValidate(object):
 
     @staticmethod
     def get_env_to_mute_undefined(module_content):
-        value = "some-value"
+        value = '1'  # Some value that make docker-compose config happy, even for port number field
         env_variables = {'NUVLA_DEPLOYMENT_ID': value,
                          'NUVLA_DEPLOYMENT_UUID': value,
                          'NUVLA_API_KEY': value,


### PR DESCRIPTION
Fix nuvla/ui#578