### PR TITLE
Scalability

### DIFF
--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -56,10 +56,11 @@ class NuvlaBoxConnector(Connector):
             r = self.api.add('nuvlabox', nuvlabox_body).data
 
             nb_id = r.get('resource-id')
-            nb = self.api.get(nb_id).data
-            nb['acl'].get('view-data', []).append(share_with)
+            if share_with:
+                nb = self.api.get(nb_id).data
+                new_view_data = nb['acl'].get('view-data', []) + share_with
 
-            self.api.edit(nb_id, {'acl': nb['acl']})
+                self.api.edit(nb_id, {'acl': nb['acl'].update({'view-data': new_view_data})})
             nuvlabox_ids.append(nb_id)
 
         return nuvlabox_ids

--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -57,10 +57,10 @@ class NuvlaBoxConnector(Connector):
 
             nb_id = r.get('resource-id')
             if share_with:
-                nb = self.api.get(nb_id).data
-                new_view_data = nb['acl'].get('view-data', []) + share_with
+                # nb = self.api.get(nb_id).data
+                # new_view_data = nb['acl'].get('view-data', []) + share_with
 
-                self.api.edit(nb_id, {'acl': nb['acl'].update({'view-data': new_view_data})})
+                self.api.edit(nb_id, {'acl': {'owners': ['group/scale-tests'], 'view-data': share_with}})
             nuvlabox_ids.append(nb_id)
 
         return nuvlabox_ids

--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -59,6 +59,8 @@ class NuvlaBoxConnector(Connector):
             self.api.edit(nb_id, {'acl': {'view-data': share_with}})
             nuvlabox_ids.append(nb_id)
 
+        return nuvlabox_ids
+
     def build_cmd_line(self, list_cmd):
         return ['docker', '-H', self.docker_api_endpoint.replace('https://', '').replace('http://', ''),
                 '--tls', '--tlscert', self.cert_file.name, '--tlskey', self.key_file.name,

--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -56,7 +56,10 @@ class NuvlaBoxConnector(Connector):
             r = self.api.add('nuvlabox', nuvlabox_body).data
 
             nb_id = r.get('resource-id')
-            self.api.edit(nb_id, {'acl': {'view-data': share_with}})
+            nb = self.api.get(nb_id).data
+            nb['acl'].get('view-data', []).append(share_with)
+
+            self.api.edit(nb_id, {'acl': nb['acl']})
             nuvlabox_ids.append(nb_id)
 
         return nuvlabox_ids

--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -13,6 +13,7 @@ from .utils import execute_cmd, create_tmp_file, timeout
 class ClusterOperationNotAllowed(Exception):
     pass
 
+
 class NuvlaBoxConnector(Connector):
     def __init__(self, **kwargs):
         super(NuvlaBoxConnector, self).__init__(**kwargs)
@@ -43,6 +44,21 @@ class NuvlaBoxConnector(Connector):
     @property
     def connector_type(self):
         return 'nuvlabox'
+
+    def create_nuvlaboxes(self, number_of_nbs, vpn_server_id, basename="nuvlabox-conector-job", version=2, share_with=[]):
+        nuvlabox_ids = []
+        for count in range(1, number_of_nbs+1):
+            nuvlabox_body = {
+                'name': f'{basename}-{count}',
+                'description': f'Automatically created by {self.connector_type} connector in Nuvla',
+                'version': version,
+                'vpn-server-id': vpn_server_id
+            }
+            r = self.api.add('nuvlabox', nuvlabox_body).data
+
+            nb_id = r.get('resource-id')
+            self.api.edit(nb_id, {'acl': {'view-data': share_with}})
+            nuvlabox_ids.append(nb_id)
 
     def build_cmd_line(self, list_cmd):
         return ['docker', '-H', self.docker_api_endpoint.replace('https://', '').replace('http://', ''),

--- a/code/src/nuvla/connector/nuvlabox_connector.py
+++ b/code/src/nuvla/connector/nuvlabox_connector.py
@@ -22,7 +22,6 @@ class NuvlaBoxConnector(Connector):
         self.job = kwargs.get("job")
         self.ssl_file = None
         self.docker_client = None
-        self.local_docker_client = docker.from_env()
         self.docker_api_endpoint = None
         self.nuvlabox_api = requests.Session()
         self.nuvlabox_api.verify = False
@@ -145,7 +144,7 @@ class NuvlaBoxConnector(Connector):
 
         if self.nuvlabox_status.get('cluster-node-role', '').lower() == 'worker':
             # workers don't have an IS
-            self.docker_client = self.local_docker_client
+            self.docker_client = docker.from_env()
 
         if self.job.get('execution-mode', '').lower() != 'pull':
             self.nb_api_endpoint = self.nuvlabox_status.get("nuvlabox-api-endpoint")
@@ -308,7 +307,7 @@ class NuvlaBoxConnector(Connector):
         return image_name
 
     def infer_docker_client(self):
-        dc = self.local_docker_client if self.job.get('execution-mode', '') == 'pull' else self.docker_client
+        dc = docker.from_env() if self.job.get('execution-mode', '') == 'pull' else self.docker_client
         return dc
 
     def run_container_from_installer(self, image, detach, container_name, volumes, command):

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+
+import re
+import copy
+import logging
+
+from nuvla.api import Api
+from nuvla.api.resources import Deployment, DeploymentParameter
+from nuvla.api.resources.base import ResourceNotFound
+from nuvla.connector import docker_connector, docker_cli_connector, \
+    docker_compose_cli_connector, kubernetes_cli_connector
+from ..actions import action
+from .deployment_start import DeploymentBase, \
+    application_params_update, get_env, initialize_connector
+
+
+action_name = 'nuvlabox_scalability_start'
+
+log = logging.getLogger(action_name)
+
+
+@action(action_name)
+class DeploymentStartJob(DeploymentBase):
+
+    def start_component(self, deployment: dict):
+        connector = initialize_connector(docker_connector, self.job, deployment)
+
+        deployment_id = Deployment.id(deployment)
+        node_instance_name = Deployment.uuid(deployment)
+        deployment_owner = Deployment.owner(deployment)
+        module_content = Deployment.module_content(deployment)
+
+        restart_policy = module_content.get('restart-policy', {})
+
+        # create deployment parameters (with empty values) for all port mappings
+        module_ports = module_content.get('ports')
+        for port in (module_ports or []):
+            target_port = port.get('target-port')
+            protocol = port.get('protocol', 'tcp')
+            if target_port is not None:
+                self.create_deployment_parameter(
+                    deployment_id=deployment_id,
+                    user_id=deployment_owner,
+                    param_name="{}.{}".format(protocol, str(target_port)),
+                    param_description="mapping for {} port {}".format(protocol, str(target_port)),
+                    node_id=node_instance_name)
+
+        registries_auth = self.private_registries_auth(deployment)
+
+        _, service = connector.start(
+            service_name=node_instance_name,
+            image=module_content['image'],
+            env=get_env(deployment),
+            mounts_opt=module_content.get('mounts'),
+            ports_opt=module_ports,
+            cpu_ratio=module_content.get('cpus'),
+            memory=module_content.get('memory'),
+            restart_policy_condition=restart_policy.get('condition'),
+            restart_policy_delay=restart_policy.get('delay'),
+            restart_policy_max_attempts=restart_policy.get('max-attempts'),
+            restart_policy_window=restart_policy.get('window'),
+            registry_auth=registries_auth[0] if registries_auth else None)
+
+        # FIXME: get number of desired replicas of Replicated service from deployment. 1 for now.
+        desired = 1
+
+        deployment_parameters = (
+            (DeploymentParameter.SERVICE_ID, connector.extract_vm_id(service)),
+            (DeploymentParameter.HOSTNAME,   self.get_hostname()),
+            (DeploymentParameter.REPLICAS_DESIRED,  str(desired)),
+            (DeploymentParameter.REPLICAS_RUNNING,  '0'),
+            (DeploymentParameter.CURRENT_DESIRED,   ''),
+            (DeploymentParameter.CURRENT_STATE,     ''),
+            (DeploymentParameter.CURRENT_ERROR,     ''),
+            (DeploymentParameter.RESTART_EXIT_CODE, ''),
+            (DeploymentParameter.RESTART_ERR_MSG,   ''),
+            (DeploymentParameter.RESTART_TIMESTAMP, ''),
+            (DeploymentParameter.RESTART_NUMBER,    ''),
+            (DeploymentParameter.CHECK_TIMESTAMP,   ''),
+        )
+
+        for deployment_parameter, value in deployment_parameters:
+            self.create_deployment_parameter(
+                param_name=deployment_parameter['name'],
+                param_value=value,
+                param_description=deployment_parameter['description'],
+                deployment_id=deployment_id,
+                node_id=node_instance_name,
+                user_id=deployment_owner)
+
+        # immediately update any port mappings that are already available
+        ports_mapping = connector.extract_vm_ports_mapping(service)
+        self.api_dpl.update_port_parameters(deployment, ports_mapping)
+
+    def start_application(self, deployment: dict):
+        deployment_id = Deployment.id(deployment)
+
+        if Deployment.is_compatibility_docker_compose(deployment):
+            connector = initialize_connector(docker_compose_cli_connector, self.job, deployment)
+        else:
+            connector = initialize_connector(docker_cli_connector, self.job, deployment)
+
+        module_content   = Deployment.module_content(deployment)
+        deployment_owner = Deployment.owner(deployment)
+        docker_compose   = module_content['docker-compose']
+        registries_auth  = self.private_registries_auth(deployment)
+
+        result, services = connector.start(docker_compose=docker_compose,
+                                           stack_name=Deployment.uuid(deployment),
+                                           env=get_env(deployment),
+                                           files=module_content.get('files'),
+                                           registries_auth=registries_auth)
+        self.job.set_status_message(result)
+
+        self.create_deployment_parameter(
+            deployment_id=deployment_id,
+            user_id=deployment_owner,
+            param_name=DeploymentParameter.HOSTNAME['name'],
+            param_value=self.get_hostname(),
+            param_description=DeploymentParameter.HOSTNAME['description'])
+
+        application_params_update(self.api_dpl, deployment, services)
+
+    def start_application_kubernetes(self, deployment: dict):
+        deployment_id = Deployment.id(deployment)
+
+        connector = initialize_connector(kubernetes_cli_connector, self.job, deployment)
+
+        module_content   = Deployment.module_content(deployment)
+        deployment_owner = Deployment.owner(deployment)
+        docker_compose   = module_content['docker-compose']
+        registries_auth  = self.private_registries_auth(deployment)
+
+        result, services = connector.start(docker_compose=docker_compose,
+                                           stack_name=Deployment.uuid(deployment),
+                                           env=get_env(deployment),
+                                           files=module_content.get('files'),
+                                           registries_auth=registries_auth)
+
+        self.job.set_status_message(result)
+
+        self.create_deployment_parameter(
+            deployment_id=deployment_id,
+            user_id=deployment_owner,
+            param_name=DeploymentParameter.HOSTNAME['name'],
+            param_value=self.get_hostname(),
+            param_description=DeploymentParameter.HOSTNAME['description'])
+
+        application_params_update(self.api_dpl, deployment, services)
+
+    def handle_deployment(self, deployment: dict):
+
+        if Deployment.is_component(deployment):
+            self.start_component(deployment)
+        elif Deployment.is_application(deployment):
+            self.start_application(deployment)
+        elif Deployment.is_application_kubernetes(deployment):
+            self.start_application_kubernetes(deployment)
+
+        self.create_user_output_params(deployment)
+
+    def start_deployment(self):
+        deployment_id = self.job['target-resource']['href']
+
+        log.info('Job started for {}.'.format(deployment_id))
+
+        deployment = self.api_dpl.get(deployment_id)
+
+        self.job.set_progress(10)
+
+        try:
+            self.handle_deployment(deployment.data)
+        except Exception as ex:
+            log.error('Failed to {0} {1}: {2}'.format(self.job['action'], deployment_id, ex))
+            try:
+                self.job.set_status_message(repr(ex))
+                self.api_dpl.set_state_error(deployment_id)
+            except Exception as ex_state:
+                log.error('Failed to set error state for {0}: {1}'.format(deployment_id, ex_state))
+
+            raise ex
+
+        self.api_dpl.set_state_started(deployment_id)
+
+        return 0
+
+    def do_work(self):
+        return self.start_deployment()

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -49,18 +49,20 @@ class NuvlaBoxScalabilityStartJob(object):
 
             depl_id = depl.get('resource-id')
 
-            self.api.edit(depl_id, {
-                "parent": credential_id,
-                "module": {
-                    "content": {
-                        "environmental-variable": [
-                            {
-                                "name": "NUVLABOX_ENGINE_VERSION",
-                                "value": release
-                            },
-                            {
-                                "name": "NUVLABOX_UUID",
-                                "value": id}]}}})
+            depl = self.api.get(depl_id).data
+            depl['parent'] = credential_id
+            depl['module']['content']['environmental-variables'] = [
+                {
+                    "name": "NUVLABOX_ENGINE_VERSION",
+                    "value": release
+                },
+                {
+                    "name": "NUVLABOX_UUID",
+                    "value": id
+                }
+            ]
+
+            self.api.edit(depl_id, depl)
 
             self.api.get(depl_id + "/start")
 

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -63,5 +63,7 @@ class NuvlaBoxScalabilityStartJob(object):
 
             self.api.get(depl_id + "/start")
 
+        return 0
+
     def do_work(self):
         return self.start_scalability_test()

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -28,9 +28,9 @@ class NuvlaBoxScalabilityStartJob(object):
         release = payload.get('nuvlabox-release')
         credential_id = payload.get('credential-id')
 
-        if not size or not module_id or not vpn_server_id or not release or not credential_id:
+        if size is None or not module_id or not vpn_server_id or not release or not credential_id:
             raise Exception(f'The {action_name} job needs a payload with the following fields: '
-                            f'size, module-id, vpn-server-id, nuvlabox-release, credential-id.'
+                            f'size, module-id, vpn-server-id, nuvlabox-release, credential-id. '
                             f'Payload provided: {payload}')
 
         return size, module_id, vpn_server_id, credential_id, \

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -12,6 +12,7 @@ from nuvla.connector import docker_connector, docker_cli_connector, \
 from ..actions import action
 from .deployment_start import DeploymentBase, \
     application_params_update, get_env, initialize_connector
+from nuvla.connector import nuvlabox_connector as NB
 
 
 action_name = 'nuvlabox_scalability_start'

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -47,9 +47,10 @@ class NuvlaBoxScalabilityStartJob(object):
         for id in nb_ids:
             depl = self.api.add('deployment', {'module': {'href': module_id}}).data
 
-            depl_id = depl.id
+            depl_id = depl.get('resource-id')
 
             self.api.edit(depl_id, {
+                "parent": credential_id,
                 "module": {
                     "content": {
                         "environmental-variable": [

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -30,7 +30,8 @@ class NuvlaBoxScalabilityStartJob(object):
 
         if not size or not module_id or not vpn_server_id or not release or not credential_id:
             raise Exception(f'The {action_name} job needs a payload with the following fields: '
-                            f'size, application-id, vpn-server-id, nuvlabox-release, credential-id')
+                            f'size, module-id, vpn-server-id, nuvlabox-release, credential-id.'
+                            f'Payload provided: {payload}')
 
         return size, module_id, vpn_server_id, credential_id, \
                payload.get('name', action_name), release, \

--- a/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
+++ b/code/src/nuvla/job/actions/nuvlabox_scalability_start.py
@@ -13,7 +13,7 @@ log = logging.getLogger(action_name)
 
 
 @action(action_name)
-class DeploymentStartJob(object):
+class NuvlaBoxScalabilityStartJob(object):
 
     def __init__(self, _, job):
         self.job = job
@@ -62,6 +62,5 @@ class DeploymentStartJob(object):
 
             self.api.get(depl_id + "/start")
 
-
     def do_work(self):
-        return self.start_deployment()
+        return self.start_scalability_test()


### PR DESCRIPTION
fixes https://github.com/nuvlabox/deployment/issues/45

@mebster this new job takes care of:
 - creating the NB resources
 - sharing them with the testing user (view-data only)
 - starting one app deployment of the NB dry-run for each NB

This job requires a payload to be passed:
```
{
  "size": number, # how many NBs to launch
  "module-id": id, # Nuvla ID of the app to be deployed (the NBE dry run app)
  "vpn-server-id": id, # The Nuvla IS ID of the VPN server to be used for the NBs
  "nuvlabox-release": string, # The release number of the NBE to be installed. For example 2.0.1 (needs to be >=2.0.0)
  "credential-id": id, # Nuvla ID of the IS credential for deploying the "module-id" above
  "name-identifier": string, # a random identifier so that we can tag these Nuvla resources for cleaning up later
  "share-with": list, # list of user IDs to share the NBs with
}
```

Things that this job doesn't do: cleanup -> if the job fails, or once the scale test is finished, there is not cleanup provided...we'd need to rely on the name-identifier above to run a manual cleanup. The bulk features should solve this.
