### PR TITLE
Docker compose validator bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+  - Exceptions handling for shell command executors and docker-compose config 
+    function
+  - 
+### Changed
+  - Simplified docker compose validation. Now it only parses the environmental
+    variables to adapt them to the docker-compose tool. It also has a better
+    exception handling.
+
 ## [2.19.0] - 2022-03-08
 
 ### Added

--- a/code/src/nuvla/connector/docker_compose.py
+++ b/code/src/nuvla/connector/docker_compose.py
@@ -21,6 +21,7 @@ def instantiate_from_cimi(api_infrastructure_service, api_credential):
 class ComposeValidatorException(Exception):
     ...
 
+
 class DockerCompose(Connector):
 
     def __init__(self, **kwargs):
@@ -300,10 +301,10 @@ class DockerCompose(Connector):
             try:
                 result = execute_cmd(cmd, env=env).stdout
 
-            except CMDExecutionException as exErr:
-                raise ComposeValidatorException(exErr)
+            except CMDExecutionException as ex:
+                raise ComposeValidatorException(ex)
 
-            except CMDTimeOutException as timedErr:
-                log.error("Command {} timed out with error: {}".format(cmd, timedErr))
+            except CMDTimeOutException as ex:
+                log.error("Command {} timed out with error: {}".format(cmd, ex))
 
         return result

--- a/code/src/nuvla/connector/utils.py
+++ b/code/src/nuvla/connector/utils.py
@@ -72,7 +72,7 @@ def execute_cmd(cmd, **kwargs) -> CompletedProcess:
     except TimeoutExpired:
         message = 'Command execution timed out after {} seconds'.format(timeout)
         log.exception(message)
-        raise Exception(message)
+        raise CMDTimeOutException(message)
     if result.returncode == 0:
         return result
     else:

--- a/code/src/nuvla/connector/utils.py
+++ b/code/src/nuvla/connector/utils.py
@@ -48,6 +48,14 @@ def append_os_env(env):
     return final_env
 
 
+class CMDExecutionException(Exception):
+    ...
+
+
+class CMDTimeOutException(Exception):
+    ...
+
+
 def execute_cmd(cmd, **kwargs) -> CompletedProcess:
     if kwargs.get('env'):
         opt_env = append_os_env(kwargs.get('env'))
@@ -69,7 +77,7 @@ def execute_cmd(cmd, **kwargs) -> CompletedProcess:
         return result
     else:
         log.exception(result)
-        raise Exception(result.stderr)
+        raise CMDExecutionException(result.stderr)
 
 
 def join_stderr_stdout(process_result: CompletedProcess):

--- a/code/src/nuvla/job/actions/application_docker_compose_validate.py
+++ b/code/src/nuvla/job/actions/application_docker_compose_validate.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import List, Dict, Any, Union
-
-import yaml
+from typing import Dict, Any
 
 from ..actions import action
 from ...connector.docker_compose import DockerCompose, ComposeValidatorException
@@ -23,8 +21,8 @@ class ApplicationDockerComposeValidate(object):
     @staticmethod
     def get_env_to_mute_undefined(module_content: Dict[str, Any]) -> Dict[str, str]:
         """
-        Initializes a dictionary with an entry for every environmental variable parsed. In sort, this is a variable
-        parser
+        Initializes a dictionary with an entry for every environmental variable parsed.
+        In sort, this is a variable parser.
 
         Args:
             module_content: Dictionary where the env variables are parsed

--- a/code/src/nuvla/job/actions/application_docker_compose_validate.py
+++ b/code/src/nuvla/job/actions/application_docker_compose_validate.py
@@ -36,8 +36,7 @@ class ApplicationDockerComposeValidate(object):
         it_env: Dict[str, Any]
         for it_env in module_content.get('environmental-variables', []):
             try:
-                if it_env['name'] and not it_env['name'].isspace():
-                    env_variables[it_env['name']] = it_env.get('value', '')
+                env_variables[it_env['name']] = it_env.get('value', '')
             except KeyError as keyErr:
                 log.error("Environmental variable name not found {}".format(keyErr))
 

--- a/code/src/nuvla/job/actions/application_docker_compose_validate.py
+++ b/code/src/nuvla/job/actions/application_docker_compose_validate.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import List, Dict, Any, Union
+
 import yaml
-from ...connector.docker_compose import DockerCompose
+
 from ..actions import action
+from ...connector.docker_compose import DockerCompose, ComposeValidatorException
 
 action_name = 'validate-docker-compose'
 
@@ -18,31 +21,25 @@ class ApplicationDockerComposeValidate(object):
         self.api = job.api
 
     @staticmethod
-    def get_env_to_mute_undefined(module_content):
-        aux_port_value = 1  # Some value that make docker-compose config happy, even for port number field
-        aux_volume_value = '/path/{}/'
+    def get_env_to_mute_undefined(module_content: Dict[str, Any]) -> Dict[str, str]:
+        """
+        Initializes a dictionary with an entry for every environmental variable parsed. In sort, this is a variable
+        parser
 
-        env_variables = {'NUVLA_DEPLOYMENT_ID': str(aux_port_value),
-                         'NUVLA_DEPLOYMENT_UUID': str(aux_port_value),
-                         'NUVLA_API_KEY': str(aux_port_value),
-                         'NUVLA_API_SECRET': str(aux_port_value),
-                         'NUVLA_ENDPOINT': str(aux_port_value)}
+        Args:
+            module_content: Dictionary where the env variables are parsed
 
-        compose_dict = yaml.safe_load(module_content['docker-compose'])
-
-        for env_var in module_content.get('environmental-variables', []):
-            for _, service in compose_dict['services'].items():
-                try:
-                    if 'ports' in service.keys() and any(env_var['name'] in s_port for s_port in service['ports']):
-                        env_variables[env_var['name']] = str(aux_port_value)
-                    else:
-                        env_variables[env_var['name']] = aux_volume_value.format(aux_port_value)
-
-                    aux_port_value += 1
-
-                except KeyError as err:
-                    log.warning("Key {} not present in compose file {}".format('ports', err))
-                    continue
+        Returns:
+            a dictionary with an entry for every environmental variable parsed.
+        """
+        env_variables: Dict[str, str] = {}
+        it_env: Dict[str, Any]
+        for it_env in module_content.get('environmental-variables', []):
+            try:
+                if it_env['name'] and not it_env['name'].isspace():
+                    env_variables[it_env['name']] = it_env.get('value', '')
+            except KeyError as keyErr:
+                log.error("Environmental variable name not found {}".format(keyErr))
 
         return env_variables
 
@@ -57,18 +54,12 @@ class ApplicationDockerComposeValidate(object):
 
         try:
             DockerCompose.config(docker_compose=module['content']['docker-compose'],
-                                 env=self.get_env_to_mute_undefined(module['content']))
+                                 env=self.get_env_to_mute_undefined(module['content']),
+                                 )
             self.api.edit(module_id, {'valid': True,
                                       'validation-message': 'Docker-compose valid.'})
 
-        except yaml.YAMLError as ymlExc:
-            log.warning("Error reading .yml file. This should have already been handled by UI")
-            log.exception(ymlExc)
-            self.job.set_status_message(str(ymlExc))
-            self.api.edit(module_id, {'valid': False,
-                                      'validation-message': str(ymlExc)})
-
-        except Exception as ex:
+        except ComposeValidatorException as ex:
             self.job.set_status_message(str(ex))
             self.api.edit(module_id, {'valid': False,
                                       'validation-message': str(ex)})

--- a/code/src/nuvla/job/actions/application_docker_compose_validate.py
+++ b/code/src/nuvla/job/actions/application_docker_compose_validate.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
-
+""" Nuvla Docker-compose validator module """
 import logging
 from typing import Dict, Any
 
 from ..actions import action
 from ...connector.docker_compose import DockerCompose, ComposeValidatorException
 
-action_name = 'validate-docker-compose'
+ACTION_NAME = 'validate-docker-compose'
 
-log = logging.getLogger(action_name)
+log = logging.getLogger(ACTION_NAME)
 
 
-@action(action_name)
-class ApplicationDockerComposeValidate(object):
-
+@action(ACTION_NAME)
+class ApplicationDockerComposeValidate:
+    """
+    Executes the validation of the docker-compose file for application deployment
+    """
     def __init__(self, _, job):
         self.job = job
         self.api = job.api
@@ -35,15 +37,22 @@ class ApplicationDockerComposeValidate(object):
         for it_env in module_content.get('environmental-variables', []):
             try:
                 env_variables[it_env['name']] = it_env.get('value', '')
-            except KeyError as keyErr:
-                log.error("Environmental variable name not found {}".format(keyErr))
+            except KeyError as ex:
+                log.error(f"Environmental variable name not found {ex}")
 
         return env_variables
 
     def do_work(self):
+        """
+        Main method for validator class.
+
+        Returns:
+            0 on success, 1 otherwise
+
+        """
         module_id = self.job['target-resource']['href']
 
-        log.info('Job started for {}.'.format(module_id))
+        log.info(f'Job started for {module_id}.')
 
         module = self.api.get(module_id).data
 

--- a/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
+++ b/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
@@ -1,101 +1,56 @@
 #!/usr/bin/env python
 
 import unittest
-from nuvla.job.actions.application_docker_compose_validate import \
-    ApplicationDockerComposeValidate
-
-
-def clean_return(ret: dict):
-    ret.pop('NUVLA_DEPLOYMENT_ID')
-    ret.pop('NUVLA_DEPLOYMENT_UUID')
-    ret.pop('NUVLA_API_KEY')
-    ret.pop('NUVLA_API_SECRET')
-    ret.pop('NUVLA_ENDPOINT')
-    return ret
+from typing import Dict, Any
+from nuvla.job.actions.application_docker_compose_validate import ApplicationDockerComposeValidate
 
 
 class TestApplicationDockerComposeValidate(unittest.TestCase):
 
     def test_get_env_to_mute_undefined(self):
-        tested_function = \
-            ApplicationDockerComposeValidate.get_env_to_mute_undefined
-        volumes = ['$VOL_1:$VOL_2']
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'name': "ENV_1"},
+            {'name': "ENV_2"}
+        ]}
 
-        # Single service only with volumes defined
-        single_srvc_yml = {
-            'services': {
-                'socat': {
-                    'volumes': volumes
-                }
-            },
-        }
-        single_service_content = {
-            'docker-compose': str(single_srvc_yml),
-            'environmental-variables':
-                [{'name': 'VOL_1', 'required': False},
-                 {'name': 'VOL_2', 'required': False}]
-        }
-        # Non ports should be asxigned a path-type string
-        for env_name, value in clean_return(tested_function(
-                single_service_content)).items():
-            self.assertFalse(value.isnumeric())
+        expected: Dict[str, str] = {"ENV_1": "", "ENV_2": ""}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
 
-        # Multiple service with volumes defined
-        single_srvc_yml = {
-            'services': {
-                'socat': {
-                    'volumes': volumes
-                },
-                'tcl': {
-                    'volumes': [
-                        '$VOL_3:$VOL_4'
-                    ]
-                }
-            },
-        }
-        single_service_content = {
-            'docker-compose': str(single_srvc_yml),
-            'environmental-variables':
-                [{'name': 'VOL_1', 'required': False},
-                 {'name': 'VOL_2', 'required': False},
-                 {'name': 'VOL_3', 'required': False},
-                 {'name': 'VOL_4', 'required': False}]
-        }
-        for env_name, value in clean_return(
-                tested_function(single_service_content)).items():
-            self.assertFalse(value.isnumeric())
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'name': "ENV_1", "value": 50},
+            {'name': "ENV_2", "value": "30"}
+        ]}
+        expected: Dict[str, str] = {"ENV_1": 50, "ENV_2": "30"}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
 
-        text_dict = {
-            'version': '3.5',
-            'services': {
-                'socat': {
-                    'image': 'sixsq/socat:latest',
-                    'ports': [
-                        '${EXPOSED_PORT}:1234'
-                    ],
-                    'volumes': volumes,
-                    'environment': [
-                        'DESTINATION=${DESTINATION}',
-                        'EXPOSED_PORT=${EXPOSED_PORT}'
-                    ]
-                }
-            },
-        }
-        module_content = {
-            'docker-compose': str(text_dict),
-            'environmental-variables':
-                [{'name': 'EXPOSED_PORT', 'required': False},
-                 {'name': 'DESTINATION', 'required': False},
-                 {'name': 'VOL_1', 'required': False},
-                 {'name': 'VOL_2', 'required': False}]
-        }
-        expected_return = {
-            'EXPOSED_PORT': '1',
-            'DESTINATION': '/path/2/',
-            'VOL_1': '/path/3/',
-            'VOL_2': '/path/4/'}
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'name': "ENV_1"},
+            {'name': "ENV_2", "value": "30"}
+        ]}
+        expected: Dict[str, str] = {"ENV_1": "", "ENV_2": "30"}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
 
-        # Check the expected dictionary
-        test_return = clean_return(tested_function(module_content))
-        self.assertTrue(test_return['EXPOSED_PORT'].isnumeric())
-        self.assertEqual(expected_return, test_return)
+        test_input: Dict[str, Any] = {}
+        expected: Dict[str, str] = {}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
+
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'nam': "ENV_1"},
+            {'name': "ENV_2", "value": "30"}
+        ]}
+        expected: Dict[str, str] = {"ENV_2": "30"}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
+
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'name': " "},
+            {'name': "ENV_2", "value": "30"}
+        ]}
+        expected: Dict[str, str] = {"ENV_2": "30"}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
+
+        test_input: Dict[str, Any] = {'environmental-variables': [
+            {'name': ""},
+            {'name': "ENV_2", "value": "30"}
+        ]}
+        expected: Dict[str, str] = {"ENV_2": "30"}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))

--- a/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
+++ b/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
@@ -54,3 +54,11 @@ class TestApplicationDockerComposeValidate(unittest.TestCase):
         ]}
         expected: Dict[str, str] = {"ENV_2": "30"}
         self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
+
+        test_input: Dict[str, Any] = {'environmental-variables': []}
+        expected: Dict[str, str] = {}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
+
+        test_input: Dict[str, Any] = {}
+        expected: Dict[str, str] = {}
+        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))

--- a/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
+++ b/code/tests/nuvla/job/actions/application_docker_compose_validate_test.py
@@ -41,20 +41,6 @@ class TestApplicationDockerComposeValidate(unittest.TestCase):
         expected: Dict[str, str] = {"ENV_2": "30"}
         self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
 
-        test_input: Dict[str, Any] = {'environmental-variables': [
-            {'name': " "},
-            {'name': "ENV_2", "value": "30"}
-        ]}
-        expected: Dict[str, str] = {"ENV_2": "30"}
-        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
-
-        test_input: Dict[str, Any] = {'environmental-variables': [
-            {'name': ""},
-            {'name': "ENV_2", "value": "30"}
-        ]}
-        expected: Dict[str, str] = {"ENV_2": "30"}
-        self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))
-
         test_input: Dict[str, Any] = {'environmental-variables': []}
         expected: Dict[str, str] = {}
         self.assertDictEqual(expected, ApplicationDockerComposeValidate.get_env_to_mute_undefined(test_input))


### PR DESCRIPTION
Simplifies the validation process of docker-compose files. Only parses the existing environmental variables. Docker client validation tool will report an error if the env. variable is not defined and it is required.