### PR TITLE
deployment: provide NuvlaEdge IP addresses as output parameters.

### DIFF
--- a/code/src/nuvla/connector/utils.py
+++ b/code/src/nuvla/connector/utils.py
@@ -63,7 +63,9 @@ def execute_cmd(cmd, **kwargs) -> CompletedProcess:
     opt_input = kwargs.get('input')
     timeout = kwargs.get('timeout', 120)
     stderr = STDOUT if kwargs.get('sterr_in_stdout', False) else PIPE
-    log.debug('Run command (timeout: %s): %s \nwith environment: %s \nwith input: %s',
+    log.debug('Run command (timeout: %s): %s \n'
+              'with environment: %s \n'
+              'with input: %s',
               timeout, cmd, opt_env, opt_input)
     try:
         result = run(cmd, stdout=PIPE, stderr=stderr, env=opt_env, input=opt_input,

--- a/code/src/nuvla/job/actions/deployment_stop.py
+++ b/code/src/nuvla/job/actions/deployment_stop.py
@@ -21,6 +21,9 @@ log = logging.getLogger(action_name)
 @action(action_name, True)
 class DeploymentStopJob(DeploymentBase):
 
+    def __init__(self, _, job):
+        super().__init__(_, job, log)
+
     def try_delete_deployment_credentials(self, deployment_id):
         cred_api = Credential(self.api, subtype='dummy')
         credentials = cred_api.find_parent(deployment_id)
@@ -74,7 +77,7 @@ class DeploymentStopJob(DeploymentBase):
 
         self.job.set_progress(10)
 
-        self.try_handle_raise_exception(log)
+        self.try_handle_raise_exception()
 
         self.try_delete_deployment_credentials(self.deployment_id)
 

--- a/code/src/nuvla/job/actions/deployment_update.py
+++ b/code/src/nuvla/job/actions/deployment_update.py
@@ -3,8 +3,7 @@ import logging
 
 from nuvla.api.resources import Deployment
 from ..actions import action
-from .utils.deployment_utils import (application_params_update,
-                                     DeploymentBase,
+from .utils.deployment_utils import (DeploymentBase,
                                      get_env,
                                      get_connector_class,
                                      get_connector_name,
@@ -17,6 +16,9 @@ log = logging.getLogger(action_name)
 
 @action(action_name, True)
 class DeploymentUpdateJob(DeploymentBase):
+
+    def __init__(self, _, job):
+        super().__init__(_, job, log)
 
     @staticmethod
     def get_update_params_docker_service(deployment, registries_auth):
@@ -60,10 +62,10 @@ class DeploymentUpdateJob(DeploymentBase):
         deployment      = self.deployment.data
         connector_name  = get_connector_name(deployment)
         connector_class = get_connector_class(connector_name)
-        registries_auth = self.private_registries_auth(deployment)
+        registries_auth = self.private_registries_auth()
         connector       = initialize_connector(connector_class, self.job, self.deployment)
 
-        self.create_user_output_params(deployment, log)
+        self.create_user_output_params()
 
         self.job.set_progress(20)
 
@@ -83,10 +85,10 @@ class DeploymentUpdateJob(DeploymentBase):
             if ports_mapping:
                 self.api_dpl.update_port_parameters(deployment, ports_mapping)
         else:
-            application_params_update(self.api_dpl, deployment, services)
+            self.application_params_update(services)
 
         self.api_dpl.set_state_started(self.deployment_id)
         return 0
 
     def do_work(self):
-        return self.try_handle_raise_exception(log)
+        return self.try_handle_raise_exception()


### PR DESCRIPTION
- update output parameter "hostname" in deployment_state action.
- prevent having to pass "log" and "deployment" objects to method of DeploymentBase class.

![Screenshot Nuvla deployment output parameters](https://github.com/nuvla/job-engine/assets/2462866/e15270f4-e093-4481-b0e4-74a5767232b8)
